### PR TITLE
Remove deprecated SPI functions and insert new one, remove guard whic…

### DIFF
--- a/.github/workflows/doxygen_gh.yml
+++ b/.github/workflows/doxygen_gh.yml
@@ -13,16 +13,16 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: ${{ runner.os }}-pip-
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
 
     - name: Install dependencies
       run: |
@@ -42,7 +42,7 @@ jobs:
         #python doxyifx.py release ${{ secrets.GH_USER }} ${{ secrets.GITHUB_TOKEN }}
     
     - name: GH Pages Deployment
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       if: success()
       with:
         publish_dir: ./docs/doxygen/build/html/

--- a/src/framework/arduino/pal/spic-arduino.cpp
+++ b/src/framework/arduino/pal/spic-arduino.cpp
@@ -14,7 +14,7 @@
  * This function is setting the basics for a SPIC and the default spi.
  *
  */
-SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPI_CLOCK_DIV16)
+SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(ARDUINO_SPI_CLOCK)
 {
 	spi = &SPI;
 }
@@ -28,7 +28,7 @@ SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPI_CLOCK_DIV16)
  * @param mode   SPI mode
  * @param clock  SPI clock divider
  */
-SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint8_t clock) : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPI_CLOCK_DIV16)
+SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock) : lsb(LSBFIRST), mode(SPI_MODE1), clock(ARDUINO_SPI_CLOCK)
 {
 	this->lsb = lsb;
 	this->mode = mode;
@@ -48,7 +48,7 @@ SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint8_t clock) : lsb(LSBFIRST), mode
  * @param mosiPin  mosi pin number
  * @param sckPin   systemclock pin number
  */
-SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin) : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPI_CLOCK_DIV16)
+SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin) : lsb(LSBFIRST), mode(SPI_MODE1), clock(ARDUINO_SPI_CLOCK)
 {
 	this->csPin = csPin;
 	this->misoPin = misoPin;
@@ -68,9 +68,7 @@ SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin
 Error_t SPICIno::init()
 {
 	spi->begin();
-	spi->setBitOrder(this->lsb);
-	spi->setClockDivider(this->clock);
-	spi->setDataMode(this->mode);
+	spi->beginTransaction(SPISettings(SPEED, this->lsb, this->mode));
 	return OK;
 }
 

--- a/src/framework/arduino/pal/spic-arduino.hpp
+++ b/src/framework/arduino/pal/spic-arduino.hpp
@@ -36,11 +36,11 @@ class SPICIno: virtual public SPIC
 		SPIClass    *spi;
 		uint8_t     lsb;
 		uint8_t     mode;
-		uint8_t     clock;
+		uint32_t    clock;
 
 	public:
 					SPICIno();
-					SPICIno(uint8_t lsb, uint8_t mode, uint8_t clock);
+					SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock);
 					SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin=MISO, uint8_t mosiPin=MOSI, uint8_t sckPin=SCK);
 					~SPICIno();
 		Error_t     init();

--- a/src/framework/arduino/wrapper/tle94112-platf-ino.hpp
+++ b/src/framework/arduino/wrapper/tle94112-platf-ino.hpp
@@ -9,7 +9,6 @@
 #ifndef TLE94112_PLATF_INO_HPP_
 #define TLE94112_PLATF_INO_HPP_
 
-// Do not reduce the ussage to this boards, all other with SPI will work too
 
 /**
  * @addtogroup platfIno

--- a/src/framework/arduino/wrapper/tle94112-platf-ino.hpp
+++ b/src/framework/arduino/wrapper/tle94112-platf-ino.hpp
@@ -9,7 +9,7 @@
 #ifndef TLE94112_PLATF_INO_HPP_
 #define TLE94112_PLATF_INO_HPP_
 
-#if defined(ARDUINO_AVR_UNO) || defined(XMC1100_Boot_Kit) || defined(XMC4700_Relax_Kit) /**< Arduino Uno, XMC1100 Boot Kit or XMC4700 Relax Kit */
+// Do not reduce the ussage to this boards, all other with SPI will work too
 
 /**
  * @addtogroup platfIno
@@ -43,5 +43,4 @@
 
 /** @} */
 
-#endif /** #ifdef **/
 #endif /** TLE94112_PLATF_INO_HPP_ **/


### PR DESCRIPTION
…h narrows the use to only three possible boards

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
This pull request includes several changes to the `SPICIno` class in the Arduino framework and adjustments to the `tle94112-platf-ino.hpp` file. The primary focus is on updating the SPI clock configuration and making the code more flexible for different boards.

The second part is to remove deprecated SPI functions and insert the right `beginTransaction` function
