### PR TITLE
Desmakers 4500

### DIFF
--- a/src/corelib/tle94112-motor-ino.hpp
+++ b/src/corelib/tle94112-motor-ino.hpp
@@ -1,0 +1,29 @@
+/**
+ * @file        tle94112-motor-ino.hpp
+ * @brief       TLE94112 Motor Arduino API
+ * @copyright   Copyright (c) 2019-2020 Infineon Technologies AG
+ * @details     This file can optionally be included in projects that use an Infineon
+ *              DC Motor Control Shield with TLE94112
+ *              It provides a higher abstraction for controlling motors with the TLE94112
+ *              acting as an output driver
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef TLE94112MOTOR_INO_HPP_
+#define TLE94112MOTOR_INO_HPP_
+
+#include "tle94112-ino.hpp"
+#include "tle94112-motor.hpp"
+
+/**
+ * @class Tle94112MotorIno
+ *
+ * @brief represents a motor connected to a TLE94112
+ *
+ * This file exists only for compatibility with the Arduino setup.
+ *
+ * @see Tle94112
+ */
+
+#endif /** TLE94112MOTOR_INO_HPP_ **/

--- a/src/corelib/tle94112-types.hpp
+++ b/src/corelib/tle94112-types.hpp
@@ -30,6 +30,40 @@ namespace tle94112
         READ_ERROR  = -3,    /**< Read error */
         WRITE_ERROR = -4,    /**< Write error */
     };
+
+    #define REG_ACT_1               0x03
+    #define REG_ACT_2               0x43
+    #define REG_ACT_3               0x23
+
+    #define REG_MODE_1              0x63
+    #define REG_MODE_2              0x13
+    #define REG_MODE_3              0x53
+
+    #define REG_PWM_CH_FREQ         0x33
+
+    #define REG_PWM_DC_1            0x73
+    #define REG_PWM_DC_2            0x0B
+    #define REG_PWM_DC_3            0x4B
+
+    #define REG_SYS_DIAG            0x1B
+    #define REG_ERR1                0x5B
+    #define REG_ERR2                0x3B
+    #define REG_ERR3                0x7B
+    #define REG_ERR4                0x07
+    #define REG_ERR5                0x47
+    #define REG_ERR6                0x27
+
+    #define REG_FW_OL               0x2B
+    #define REG_FW_CTRL             0x6B
+
+    #define HL_HL                   0b10011001
+    #define HL_LH                   0b10010110
+    #define LH_HL                   0b01101001
+    #define LH_LH                   0b01100110
+
+    #define HH_LL                   0b10100101
+    #define LL_HH                   0b01011010
+
     /** @} */
 
     /** @} */

--- a/src/corelib/tle94112.hpp
+++ b/src/corelib/tle94112.hpp
@@ -227,6 +227,28 @@ class Tle94112
 		//! \brief clears all clearable error flags
 		void clearErrors();
 
+		/*! \brief writes data bits directly to a register of the TLE94112
+		 *
+		 * \param reg   address of the register to be written to.
+		 * \param data  the data byte that has to be written.
+		 *
+		 * \see mCtrlRegAddresses
+		 * \see mCtrlRegData
+		 */
+		void directWriteReg(uint8_t reg, uint8_t data);
+
+		/*! \brief reads one byte from a status register of the TLE94112
+		 *
+		 * \param reg status register number(mapping array index / StatusRegisters constant) of the register
+		 *
+		 * \return data byte that has been read
+		 *
+		 * \see StatusRegisters
+		 * \see TLE94112_NUM_STATUS_REGS
+		 * \see mStatusRegAddresses
+		 */
+		uint8_t readStatusReg(uint8_t reg);
+
 		SPIC     *sBus;      //<! \brief SPI cover class as representation of the SPI bus
 		GPIOC    *cs;        //<! \brief shield enable GPIO to switch chipselect on/off
 		GPIOC    *en;        //<! \brief shield enable GPIO to switch shield on/off
@@ -362,18 +384,6 @@ class Tle94112
 		 * \see mCtrlRegData
 		 */
 		void writeReg(uint8_t reg, uint8_t mask, uint8_t shift, uint8_t data);
-
-		/*! \brief reads one byte from a status register of the TLE94112
-		 *
-		 * \param reg status register number(mapping array index / StatusRegisters constant) of the register
-		 *
-		 * \return data byte that has been read
-		 *
-		 * \see StatusRegisters
-		 * \see TLE94112_NUM_STATUS_REGS
-		 * \see mStatusRegAddresses
-		 */
-		uint8_t readStatusReg(uint8_t reg);
 
 		/*! \brief reads some bits from a status register of the TLE94112
 		 *

--- a/src/framework/arduino/examples/directRegisterControl/directRegisterControl.ino
+++ b/src/framework/arduino/examples/directRegisterControl/directRegisterControl.ino
@@ -1,0 +1,108 @@
+/*!
+ * \name        directRegisterControl
+ * \author      Infineon Technologies AG
+ * \copyright   2025 Infineon Technologies AG
+ * \brief       This example demonstrates how to control two motors via direct register setting
+ * \details
+ * If motors are connected to the TLE94112 on certain half bridges, than they can be controlled via direct register
+ * setting which reduces greatly the overhead and allows fast motor controlling.
+ * therefore the half bridges HB1 to HB4, HB5 to HB8 and HB9 to HB12 must be used together, either for controlling
+ * two motors on one tuple (0.9 A), or one motor on one tuple (1.8 A).
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+
+ #include <tle94112-ino.hpp>
+
+ //! Tle94112 Object
+ Tle94112Ino controller = Tle94112Ino();
+ 
+ //! Tle94112 registers for motor 1 and 2
+ uint8_t motor[2][2] = {
+   {REG_ACT_1, REG_PWM_DC_1},
+   {REG_ACT_3, REG_PWM_DC_3}
+ };
+ 
+ //! Tle94112 register for motor direction
+ volatile uint8_t oldDirection [] = { LL_HH, HH_LL };
+ 
+ /**
+  * @brief Changes the motor direction and speed
+  * The motor direction is set by the change of the High/Low switching of the motor half bridges in one register.
+  * This needs some time to change the direction, so its avoided if not needed.
+  * Setting the speed is done by setting the PWM register.
+  *
+  * @param motorNum uint8_t motor number (0 or 1)
+  * @param dir uint8_t direction (HH_LL or LL_HH for forward/backward of one motor on four half bridges)
+  * @param speed uint8_t speed (0-255)
+  * @param errorCheck bool if true, the error register is cleared after setting the speed
+  */
+ void motorSet(uint8_t motorNum, uint8_t dir, uint8_t speed, bool errorCheck = false)
+ {
+   if (dir != oldDirection[motorNum]) {
+     controller.directWriteReg(motor[motorNum][0], dir);
+     oldDirection[motorNum] = dir;
+   }
+   controller.directWriteReg(motor[motorNum][1], speed);
+   if (errorCheck) {
+     controller.clearErrors();
+   }
+ }
+ 
+ 
+ //! connect motor between halfbridge 1 and halfbridge 2
+ void setup()
+ {
+ 
+   Serial.begin(9600);
+   while (!Serial) {
+     ; // wait for serial port to connect. Needed for native USB port only
+   }
+   Serial.println("TLE94112 Motor Speed Control Example");
+   delay(1000);
+ 
+   // Enable MotorController Tle94112
+   // Note: Required to be done before starting to configure the motor
+   controller.begin();
+ 
+   // four half bridges and two PWM channels are used to control two motors
+   controller.configHB(controller.TLE_HB1, controller.TLE_HIGH, controller.TLE_PWM1);
+   controller.configHB(controller.TLE_HB2, controller.TLE_HIGH, controller.TLE_PWM1);
+   controller.configHB(controller.TLE_HB3, controller.TLE_LOW,  controller.TLE_NOPWM);
+   controller.configHB(controller.TLE_HB4, controller.TLE_LOW,  controller.TLE_NOPWM);
+ 
+   controller.configHB(controller.TLE_HB9,  controller.TLE_HIGH, controller.TLE_PWM3);
+   controller.configHB(controller.TLE_HB10, controller.TLE_HIGH, controller.TLE_PWM3);
+   controller.configHB(controller.TLE_HB11, controller.TLE_LOW,  controller.TLE_NOPWM);
+   controller.configHB(controller.TLE_HB12, controller.TLE_LOW,  controller.TLE_NOPWM);
+ 
+   // all stop
+   controller.configPWM(controller.TLE_PWM1, controller.TLE_FREQ200HZ, 0);
+   controller.configPWM(controller.TLE_PWM3, controller.TLE_FREQ200HZ, 0);
+   controller.clearErrors();
+ 
+   delay(1000);
+ 
+ }
+ 
+ 
+ void loop() {
+   controller.clearErrors();
+ 
+   Serial.println("forward / backward");
+   motorSet(0, HH_LL, 100);
+   motorSet(1, LL_HH, 100);
+   delay(1000);
+ 
+   Serial.println(" speed up / down");
+   motorSet(0, HH_LL, 255);
+   motorSet(1, LL_HH, 50);
+   delay(1000);
+ 
+   Serial.println("backward / forward ");
+   motorSet(0, LL_HH, 255);
+   motorSet(1, HH_LL, 255);
+   delay(1000);
+ 
+ }

--- a/src/framework/arduino/examples/speedControl.ino
+++ b/src/framework/arduino/examples/speedControl.ino
@@ -1,0 +1,56 @@
+/*!
+ * \name        speedControl
+ * \author      Infineon Technologies AG
+ * \copyright   2021 Infineon Technologies AG
+ * \brief       This example demonstrates how to control the speed of motor by using the PWM units of the TLE94112 shield
+ * \details
+ * Ramping the speed of the motor up and down by using PWM signals.
+ * The TLE94112 has three separate PWM units which can be attached to any combination
+ * of halfbridges. So try out to change the TLE_PWM1 to TLE_PWM2 or TLE_PWM3 to see this.
+ * You can change the motor direction by changing the HIGH/LOW status of the halfbridges
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+
+#include <tle94112-ino.hpp>
+
+//! Tle94112 Object
+Tle94112Ino controller = Tle94112Ino();
+
+//! connect motor between halfbridge 1 and halfbridge 2
+void setup() 
+{
+  // Enable MotorController Tle94112
+  // Note: Required to be done before starting to configure the motor
+  controller.begin();
+}
+
+
+void loop() {
+
+  /* Configure the motor to use PWM with a duty cycle of 0% and forward direction. */
+  controller.configPWM(controller.TLE_PWM1, controller.TLE_FREQ80HZ, 0);
+  controller.configHB(controller.TLE_HB1, controller.TLE_HIGH, controller.TLE_PWM1);
+  controller.configHB(controller.TLE_HB2, controller.TLE_LOW, controller.TLE_NOPWM);
+
+  /* Ramp up duty cycle from 0% to 100%. */
+  for (uint8_t speed = 0; speed < 255; speed++)
+  {
+    controller.configPWM(controller.TLE_PWM1, controller.TLE_FREQ80HZ, speed);
+    delay(10);
+  }
+
+  /* Configure the motor to use PWM with a duty cycle of 0% and backward direction. */
+  controller.configPWM(controller.TLE_PWM1, controller.TLE_FREQ80HZ, 0);
+  controller.configHB(controller.TLE_HB1, controller.TLE_LOW, controller.TLE_NOPWM);
+  controller.configHB(controller.TLE_HB2, controller.TLE_HIGH, controller.TLE_PWM1);
+
+  /* Ramp up duty cycle from 0% to 100%. */
+  for (uint8_t speed = 0; speed < 255; speed++)
+  {
+    controller.configPWM(controller.TLE_PWM1, controller.TLE_FREQ80HZ, 255-speed);
+    delay(10);
+  }
+
+}

--- a/src/framework/arduino/library.json
+++ b/src/framework/arduino/library.json
@@ -12,7 +12,7 @@
       "url":"https://www.infineon.com/cms/en/product/power/motor-control-ics/brushed-dc-motor-driver-ics/multi-half-bridge-ics/",
       "maintainer": true
    },
-   "version":"5.0.1",
+   "version":"5.1.0",
    "license":"MIT",
    "frameworks":"arduino",
    "platforms":[  

--- a/src/framework/arduino/library.properties
+++ b/src/framework/arduino/library.properties
@@ -1,5 +1,5 @@
 name=multi-half-bridge
-version=5.0.1
+version=5.1.0
 author=Infineon Technologies
 maintainer=Infineon Technologies <www.infineon.com>
 sentence=Library of Infineon Multi Half-Bridge IC controllers family

--- a/src/framework/arduino/pal/spic-arduino.cpp
+++ b/src/framework/arduino/pal/spic-arduino.cpp
@@ -14,7 +14,7 @@
  * This function is setting the basics for a SPIC and the default spi.
  *
  */
-SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(ARDUINO_SPI_CLOCK)
+SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
 {
 	spi = &SPI;
 }
@@ -28,7 +28,7 @@ SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(ARDUINO_SPI_CLOCK)
  * @param mode   SPI mode
  * @param clock  SPI clock divider
  */
-SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock) : lsb(LSBFIRST), mode(SPI_MODE1), clock(ARDUINO_SPI_CLOCK)
+SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock) : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
 {
 	this->lsb = lsb;
 	this->mode = mode;
@@ -48,7 +48,7 @@ SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock) : lsb(LSBFIRST), mod
  * @param mosiPin  mosi pin number
  * @param sckPin   systemclock pin number
  */
-SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin) : lsb(LSBFIRST), mode(SPI_MODE1), clock(ARDUINO_SPI_CLOCK)
+SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin) : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
 {
 	this->csPin = csPin;
 	this->misoPin = misoPin;

--- a/src/framework/arduino/pal/spic-arduino.cpp
+++ b/src/framework/arduino/pal/spic-arduino.cpp
@@ -14,7 +14,7 @@
  * This function is setting the basics for a SPIC and the default spi.
  *
  */
-SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
+SPICIno::SPICIno(): clock(SPEED)
 {
 	spi = &SPI;
 }
@@ -28,10 +28,8 @@ SPICIno::SPICIno() : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
  * @param mode   SPI mode
  * @param clock  SPI clock divider
  */
-SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock) : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
+SPICIno::SPICIno(uint32_t clock): clock(SPEED)
 {
-	this->lsb = lsb;
-	this->mode = mode;
 	this->clock = clock;
 	spi = &SPI;
 }
@@ -48,7 +46,7 @@ SPICIno::SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock) : lsb(LSBFIRST), mod
  * @param mosiPin  mosi pin number
  * @param sckPin   systemclock pin number
  */
-SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin) : lsb(LSBFIRST), mode(SPI_MODE1), clock(SPEED)
+SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin): clock(SPEED)
 {
 	this->csPin = csPin;
 	this->misoPin = misoPin;
@@ -68,14 +66,14 @@ SPICIno::SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin, uint8_t mosiPin
 Error_t SPICIno::init()
 {
 	spi->begin();
-	spi->beginTransaction(SPISettings(SPEED, this->lsb, this->mode));
+	spi->beginTransaction(SPISettings(SPEED, LSBFIRST, SPI_MODE1));
 	return OK;
 }
 
 /**
  * @brief Deinitialize the SPIC
  *
- * This function is deinitializing the chosen spi channel.
+ * This function deinitialize the chosen spi channel.
  *
  * @return      Error_t
  */

--- a/src/framework/arduino/pal/spic-arduino.hpp
+++ b/src/framework/arduino/pal/spic-arduino.hpp
@@ -26,6 +26,8 @@ using namespace tle94112;
  * @brief Arduino SPIC class
  *
  */
+
+#define SPEED 1000000
 class SPICIno: virtual public SPIC
 {
 	private:

--- a/src/framework/arduino/pal/spic-arduino.hpp
+++ b/src/framework/arduino/pal/spic-arduino.hpp
@@ -36,13 +36,11 @@ class SPICIno: virtual public SPIC
 		uint8_t     mosiPin;
 		uint8_t     sckPin;
 		SPIClass    *spi;
-		uint8_t     lsb;
-		uint8_t     mode;
 		uint32_t    clock;
 
 	public:
 					SPICIno();
-					SPICIno(uint8_t lsb, uint8_t mode, uint32_t clock);
+					SPICIno(uint32_t clock);
 					SPICIno(SPIClass &port, uint8_t csPin, uint8_t misoPin=MISO, uint8_t mosiPin=MOSI, uint8_t sckPin=SCK);
 					~SPICIno();
 		Error_t     init();

--- a/src/framework/arduino/wrapper/tle94112-ino.cpp
+++ b/src/framework/arduino/wrapper/tle94112-ino.cpp
@@ -25,13 +25,27 @@ Tle94112Ino::Tle94112Ino(void):Tle94112()
 }
 
 /**
- * @brief constructor with individual pin assignment
+ * @brief constructor with individual pin assignment for CS pin
  *
- * @param csPin  pin number of the CS pin
+ * @param csPin  pin number of the CS (chip select) pin
  */
 Tle94112Ino::Tle94112Ino(uint8_t csPin):Tle94112()
 {
 	Tle94112::en = new GPIOIno( TLE94112_PIN_EN, OUTPUT, GPIOIno::POSITIVE );
+	Tle94112::cs = new GPIOIno( csPin, OUTPUT, GPIOIno::POSITIVE );
+	Tle94112::timer = new TimerIno();
+	Tle94112::sBus = new SPICIno();
+}
+
+/**
+ * @brief constructor with individual pin assignment for CS and EN pin.
+ *
+ * @param csPin  pin number of the CS (chip select) pin
+ * @param enPin  pin number of the EN (enable) pin
+ */
+Tle94112Ino::Tle94112Ino(uint8_t csPin, uint8_t enPin):Tle94112()
+{
+	Tle94112::en = new GPIOIno( enPin, OUTPUT, GPIOIno::POSITIVE );
 	Tle94112::cs = new GPIOIno( csPin, OUTPUT, GPIOIno::POSITIVE );
 	Tle94112::timer = new TimerIno();
 	Tle94112::sBus = new SPICIno();

--- a/src/framework/arduino/wrapper/tle94112-ino.hpp
+++ b/src/framework/arduino/wrapper/tle94112-ino.hpp
@@ -26,6 +26,7 @@ class Tle94112Ino: virtual public Tle94112
 	public:
 		Tle94112Ino(void);
 		Tle94112Ino(uint8_t csPin);
+		Tle94112Ino(uint8_t csPin, uint8_t enPin);
 };
 /** @} */
 

--- a/src/framework/arduino/wrapper/tle94112-platf-ino.hpp
+++ b/src/framework/arduino/wrapper/tle94112-platf-ino.hpp
@@ -26,7 +26,7 @@
 /*!
  * Standard chip select pin for first TLE94112 shield
  */
-#define TLE94112_PIN_CS1     10
+#define TLE94112_PIN_CS1     SS
 
 /*!
  * Standard chip select pin for second TLE94112 shield


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

This pull request introduces several enhancements and refactorings to the TLE94112 motor control library, focusing on improving maintainability, compatibility, and functionality. The changes include the addition of new features for direct register control, code simplifications, and updates to constructors and constants for better platform compatibility.

### Key Changes:

#### New Features and Functionality:
* Added a new example file, `directRegisterControl.ino`, demonstrating direct register control for motor direction and speed, which reduces overhead and enables faster motor control.
* Introduced the `directWriteReg` method in `Tle94112` for direct register writes, along with an updated `readStatusReg` method for reading status registers. These changes improve the flexibility of register-level operations. [[1]](diffhunk://#diff-028e25c57dddcfbdc04d476a9158e85e35c38da10df2c87810e8939196ab4138L295-R296) [[2]](diffhunk://#diff-30a9caed213e3842cd00ca08eb95c888647e1f1f511939b3ba01c937a707bd5cR230-R251)

#### Code Simplifications:
* Simplified the `_configHB`, `_configPWM`, `_getHBOverCurrent`, and `_getHBOpenLoad` methods in `Tle94112` by directly passing member variables to `writeReg` and `readStatusReg` calls, reducing redundant variable declarations. [[1]](diffhunk://#diff-028e25c57dddcfbdc04d476a9158e85e35c38da10df2c87810e8939196ab4138L117-R130) [[2]](diffhunk://#diff-028e25c57dddcfbdc04d476a9158e85e35c38da10df2c87810e8939196ab4138L143-R144) [[3]](diffhunk://#diff-028e25c57dddcfbdc04d476a9158e85e35c38da10df2c87810e8939196ab4138L199-R192) [[4]](diffhunk://#diff-028e25c57dddcfbdc04d476a9158e85e35c38da10df2c87810e8939196ab4138L214-R204)

#### Platform Compatibility:
* Updated the default chip select pin (`TLE94112_PIN_CS1`) to use the `SS` constant for better compatibility with Arduino platforms.
* Added a new constructor in `Tle94112Ino` to support individual pin assignments for both the chip select (CS) and enable (EN) pins, enhancing flexibility for hardware configurations. [[1]](diffhunk://#diff-3614eb088f5e2e1cbffb4592fcdf0e7ea0e21b121f79650aa811185a0a998a9fR39-R52) [[2]](diffhunk://#diff-2deb31b5d09389142b9488b64d46b3bb027348c50198806c8dccefece7f8e39dR29)

#### Refactoring and Maintenance:
* Replaced hardcoded register addresses in `Tle94112::init` with defined constants from `tle94112-types.hpp`, improving maintainability and readability.
* Removed unused `lsb` and `mode` parameters from the `SPICIno` constructors and replaced them with a single `SPEED` constant for SPI clock configuration, simplifying the SPI initialization logic. [[1]](diffhunk://#diff-59810fc7271efdbe73239a79bb69eacd47838fc4d895a9d70d05d1347838b5c7L17-R17) [[2]](diffhunk://#diff-59810fc7271efdbe73239a79bb69eacd47838fc4d895a9d70d05d1347838b5c7L31-L34) [[3]](diffhunk://#diff-dcfc03ba6fc0559efd930e1ba3f51cc946a04519a89d79fe7ea726b013b12639L37-R43)

#### Documentation and Headers:
* Added a new header file, `tle94112-motor-ino.hpp`, for compatibility with Arduino projects using the TLE94112 motor control shield.
* Improved documentation for constructors and methods across several files, clarifying their purpose and parameters. [[1]](diffhunk://#diff-3614eb088f5e2e1cbffb4592fcdf0e7ea0e21b121f79650aa811185a0a998a9fL28-R30) [[2]](diffhunk://#diff-30a9caed213e3842cd00ca08eb95c888647e1f1f511939b3ba01c937a707bd5cR230-R251)
