### PR TITLE
Fixing Python Module Installation and SPI Frequency on the raspberry pi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ message( STATUS "CMAKE_BUILD_TYPE : ${CMAKE_BUILD_TYPE}" )
 message( STATUS "CMAKE_SYSTEM_NAME : ${CMAKE_SYSTEM_NAME}" )
 message( STATUS "CMAKE_SOURCE_DIR : ${CMAKE_SOURCE_DIR}" )
 
-include( CompilerSettings )
+#include(CompilerSettings)
 
 # Search for include Files
 include_directories(

--- a/src/framework/raspberrypi/CMakeLists.txt
+++ b/src/framework/raspberrypi/CMakeLists.txt
@@ -1,44 +1,69 @@
-cmake_minimum_required(VERSION 3.4...3.18)
+cmake_minimum_required(VERSION 3.12.4)
 
-project(multi_half_bridge_py)
+# Project name and languages
+set(mhbcore multi-half-bridge-corelib)
+project(${mhbcore} CXX C)
 
-# Search for include Files
+
+
+# Manually add Pybind11 path if not found automatically is needed to find pybind11
+if (NOT DEFINED PYBIND11_INCLUDE_DIRS)
+    find_package(pybind11 REQUIRED)
+    set(PYBIND11_INCLUDE_DIRS ${pybind11_INCLUDE_DIRS})
+endif()
+
+# Include directories
 include_directories(
+    ../../config/
+    ../../corelib/
+    ../../pal/
+    pal/
+    wrapper/
+    ${PYBIND11_INCLUDE_DIRS}
+)
+
+# Set header and source files
+set(Headers
     pal/
     wrapper/
 )
 
-
-set(Headers
-    pal/
-    wrapper/
-    )
-
+# List source files
 set(Sources
+    ../../corelib/tle94112-logger.cpp
+    ../../corelib/tle94112.cpp
+    ../../corelib/tle94112-motor.cpp
+    ../../pal/gpio.cpp
+    ../../pal/spic.cpp
     pal/gpio-rpi.cpp
     pal/logger-rpi.cpp
     pal/spic-rpi.cpp
     pal/timer-rpi.cpp
     wrapper/tle94112-rpi.cpp
     wrapper/tle94112-pybind.cpp
-    )
+)
 
-# add_subdirectory(tools/pybind11)
+# Add library
+add_library(${mhbcore} ${Sources})
+
+# pybind11 integration
 find_package(pybind11 REQUIRED)
+
 
 pybind11_add_module(multi_half_bridge_py ${Sources} ${Headers})
 
-# Adding RPI bcm library dependency
-find_library(bcm2835_dir NAMES  libbcm2835.a)
+
+# Add Raspberry Pi bcm library dependency
+find_library(bcm2835_dir NAMES libbcm2835.a)
 message(STATUS ${bcm2835_dir})
 
 add_library(bcm2835 STATIC IMPORTED)
 set_target_properties(bcm2835 PROPERTIES IMPORTED_LOCATION ${bcm2835_dir})
 
-# Required Libraries
+# Link libraries
 target_link_libraries(multi_half_bridge_py PUBLIC
-multi-half-bridge-corelib
-bcm2835
+    ${mhbcore}
+    bcm2835
 )
 
 # EXAMPLE_VERSION_INFO is defined by setup.py and passed into the C++ code as a

--- a/src/framework/raspberrypi/CMakeLists.txt
+++ b/src/framework/raspberrypi/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.12.4)
 
-# Project name and languages
+# Set the correct module path
+set(CMAKE_MODULE_PATH  "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake")
+
+# Define variables that would come from root CMakeLists.txt
 set(mhbcore multi-half-bridge-corelib)
+
+# Project name and languages
 project(${mhbcore} CXX C)
 
 
@@ -30,11 +35,6 @@ set(Headers
 
 # List source files
 set(Sources
-    ../../corelib/tle94112-logger.cpp
-    ../../corelib/tle94112.cpp
-    ../../corelib/tle94112-motor.cpp
-    ../../pal/gpio.cpp
-    ../../pal/spic.cpp
     pal/gpio-rpi.cpp
     pal/logger-rpi.cpp
     pal/spic-rpi.cpp
@@ -44,7 +44,7 @@ set(Sources
 )
 
 # Add library
-add_library(${mhbcore} ${Sources})
+#add_library(${mhbcore} ${Sources})
 
 # pybind11 integration
 find_package(pybind11 REQUIRED)
@@ -62,7 +62,6 @@ set_target_properties(bcm2835 PROPERTIES IMPORTED_LOCATION ${bcm2835_dir})
 
 # Link libraries
 target_link_libraries(multi_half_bridge_py PUBLIC
-    ${mhbcore}
     bcm2835
     cap
 )

--- a/src/framework/raspberrypi/CMakeLists.txt
+++ b/src/framework/raspberrypi/CMakeLists.txt
@@ -64,6 +64,7 @@ set_target_properties(bcm2835 PROPERTIES IMPORTED_LOCATION ${bcm2835_dir})
 target_link_libraries(multi_half_bridge_py PUBLIC
     ${mhbcore}
     bcm2835
+    cap
 )
 
 # EXAMPLE_VERSION_INFO is defined by setup.py and passed into the C++ code as a

--- a/src/framework/raspberrypi/install_requirements.sh
+++ b/src/framework/raspberrypi/install_requirements.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BCM_VERSION=1.73
+BCM_VERSION=1.75
 if [ "$EUID" -eq 0 ]
 then
 	echo "Please do not execute this script as root."
@@ -21,15 +21,15 @@ done
 
 if [[ $menuinput == 'Y' || $menuinput == 'y' ]]
 then
-	CFLAGS='-DBCM2835_HAVE_LIBCAP'
 	echo "Installing required packets..."
 	sudo apt-get install libcap2 libcap-dev
 	echo "Add current user to kmem group..."
 	sudo adduser $USER kmem
 	echo "Allow write access to /dev/mem by members of kmem group..."
 	echo 'SUBSYSTEM=="mem", KERNEL=="mem", GROUP="kmem", MODE="0660"' | sudo tee /etc/udev/rules.d/98-mem.rules
+	CFLAGS="-fPIC -DBCM2835_HAVE_LIBCAP"
 else
-	CFLAGS=''
+	CFLAGS="-fPIC"
 fi
 
 echo "Downloading source for BCM2835 library..."
@@ -39,7 +39,7 @@ echo "Compiling BCM2835 library..."
 tar zxvf bcm2835-$BCM_VERSION.tar.gz
 cd bcm2835-$BCM_VERSION
 
-./configure CFLAGS=$CFLAGS
+./configure CFLAGS="$CFLAGS"
 make
 
 echo "Installing BCM2835 library..."

--- a/src/framework/raspberrypi/install_requirements.sh
+++ b/src/framework/raspberrypi/install_requirements.sh
@@ -29,7 +29,7 @@ then
 	echo 'SUBSYSTEM=="mem", KERNEL=="mem", GROUP="kmem", MODE="0660"' | sudo tee /etc/udev/rules.d/98-mem.rules
 	CFLAGS="-fPIC -DBCM2835_HAVE_LIBCAP"
 else
-	CFLAGS="-fPIC"
+	CFLAGS=""
 fi
 
 echo "Downloading source for BCM2835 library..."

--- a/src/framework/raspberrypi/install_requirements.sh
+++ b/src/framework/raspberrypi/install_requirements.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BCM_VERSION=1.68
+BCM_VERSION=1.73
 if [ "$EUID" -eq 0 ]
 then
 	echo "Please do not execute this script as root."

--- a/src/framework/raspberrypi/pal/spic-rpi.cpp
+++ b/src/framework/raspberrypi/pal/spic-rpi.cpp
@@ -14,7 +14,7 @@
  * This function sets the basics for a SPIC and the default SPI.
  *
  */
-SPICRpi::SPICRpi() : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1), clock(BCM2835_SPI_CLOCK_DIVIDER_16)
+SPICRpi::SPICRpi() : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1), clock(BCM2835_SPI_CLOCK_DIVIDER_128)
 {
 
 }
@@ -28,7 +28,7 @@ SPICRpi::SPICRpi() : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1
  * @param mode   SPI mode
  * @param clock  SPI clock divider
  */
-SPICRpi::SPICRpi(uint8_t lsb, uint8_t mode, uint8_t clock) : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1), clock(BCM2835_SPI_CLOCK_DIVIDER_16)
+SPICRpi::SPICRpi(uint8_t lsb, uint8_t mode, uint8_t clock) : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1), clock(BCM2835_SPI_CLOCK_DIVIDER_128)
 {
 	this->lsb = lsb;
 	this->mode = mode;
@@ -46,7 +46,7 @@ SPICRpi::SPICRpi(uint8_t lsb, uint8_t mode, uint8_t clock) : lsb(BCM2835_SPI_BIT
  * @param mosiPin  mosi pin number
  * @param sckPin   systemclock pin number
  */
-SPICRpi::SPICRpi(uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin) : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1), clock(BCM2835_SPI_CLOCK_DIVIDER_16)
+SPICRpi::SPICRpi(uint8_t csPin, uint8_t misoPin, uint8_t mosiPin, uint8_t sckPin) : lsb(BCM2835_SPI_BIT_ORDER_LSBFIRST), mode(BCM2835_SPI_MODE1), clock(BCM2835_SPI_CLOCK_DIVIDER_128)
 {
 	this->csPin = csPin;
 	this->misoPin = misoPin;
@@ -74,7 +74,7 @@ Error_t SPICRpi::init()
         }
 	bcm2835_spi_setBitOrder(BCM2835_SPI_BIT_ORDER_LSBFIRST);      // The default
 	bcm2835_spi_setDataMode(BCM2835_SPI_MODE1);                   // The default
-    bcm2835_spi_setClockDivider(BCM2835_SPI_CLOCK_DIVIDER_32);
+    bcm2835_spi_setClockDivider(BCM2835_SPI_CLOCK_DIVIDER_128);
     bcm2835_spi_chipSelect(BCM2835_SPI_CS0);                      // The default
     bcm2835_spi_setChipSelectPolarity(BCM2835_SPI_CS0, LOW);      // The default
 	return OK;

--- a/src/framework/raspberrypi/pyproject.toml
+++ b/src/framework/raspberrypi/pyproject.toml
@@ -4,5 +4,6 @@ requires = [
     "wheel",
     "ninja; sys_platform != 'win32'",
     "cmake>=3.12",
+"pybind11>=2.13.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/src/framework/raspberrypi/setup.py
+++ b/src/framework/raspberrypi/setup.py
@@ -1,9 +1,7 @@
-
 # -*- coding: utf-8 -*-
 import os
 import sys
 import subprocess
-
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 
@@ -15,21 +13,20 @@ PLAT_TO_CMAKE = {
     "win-arm64": "ARM64",
 }
 
-
 # A CMakeExtension needs a sourcedir instead of a file list.
 # The name must be the _single_ output extension from the CMake build.
 # If you need multiple extensions, see scikit-build.
+
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=""):
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
 
-
 class CMakeBuild(build_ext):
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
 
-        # required for auto-detection of auxiliary "native" libs
+         # required for auto-detection of auxiliary "native" libs
         if not extdir.endswith(os.path.sep):
             extdir += os.path.sep
 
@@ -39,29 +36,32 @@ class CMakeBuild(build_ext):
         # Can be set with Conda-Build, for example.
         cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
 
-        # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
-        # EXAMPLE_VERSION_INFO shows you how to pass a value into the C++ code
-        # from Python.
+        # Ensure necessary environment variables are set
+        cmake_prefix_path = subprocess.check_output(
+            [sys.executable, "-m", "pybind11", "--cmakedir"]
+        ).strip().decode()
+        os.environ["CMAKE_PREFIX_PATH"] = cmake_prefix_path
+
+        # Define the CMake arguments
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}".format(extdir),
             "-DPYTHON_EXECUTABLE={}".format(sys.executable),
             "-DEXAMPLE_VERSION_INFO={}".format(self.distribution.get_version()),
-            "-DCMAKE_BUILD_TYPE={}".format(cfg),  # not used on MSVC, but no harm
+            "-DCMAKE_BUILD_TYPE={}".format(cfg),
         ]
+
         build_args = []
 
         if self.compiler.compiler_type != "msvc":
-            # Using Ninja-build since it a) is available as a wheel and b)
+             # Using Ninja-build since it a) is available as a wheel and b)
             # multithreads automatically. MSVC would require all variables be
             # exported for Ninja to pick it up, which is a little tricky to do.
             # Users can override the generator with CMAKE_GENERATOR in CMake
             # 3.15+.
             if not cmake_generator:
                 cmake_args += ["-GNinja"]
-
         else:
-
-            # Single config generators are handled "normally"
+             # Single config generators are handled "normally"
             single_config = any(x in cmake_generator for x in {"NMake", "Ninja"})
 
             # CMake allows an arch-in-generator style for backward compatibility
@@ -86,19 +86,17 @@ class CMakeBuild(build_ext):
             # self.parallel is a Python 3 only way to set parallel jobs by hand
             # using -j in the build_ext call, not supported by pip or PyPA-build.
             if hasattr(self, "parallel") and self.parallel:
-                # CMake 3.12+ only.
+                 # CMake 3.12+ only.
                 build_args += ["-j{}".format(self.parallel)]
 
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
 
+        subprocess.check_call(["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp)
         subprocess.check_call(
-            ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp
+            ["cmake", "--build", ".","--target", "multi_half_bridge_py"] + build_args,
+            cwd=self.build_temp
         )
-        subprocess.check_call(
-            ["cmake", "--build", ".", "--target", "multi_half_bridge_py"] + build_args, cwd=self.build_temp
-        )
-
 # The information here can also be placed in setup.cfg - better separation of
 # logic and declaration, and simpler if you include description/version in a file.
 setup(
@@ -108,18 +106,18 @@ setup(
     description="Python Library for Infineon's multi half-bridge IC drivers",
     long_description="Python library for Infineons multi half-bridge IC drivers",
     project_urls={
-        'Source' : 'https://github.com/Infineon/multi-half-bridge',
+        'Source': 'https://github.com/Infineon/multi-half-bridge',
         'Wiki': 'https://github.com/Infineon/multi-half-bridge/wiki',
-        'IC Prodcuts Page' : 'https://www.infineon.com/cms/de/product/power/motor-control-ics/brushed-dc-motor-driver-ics/multi-half-bridge-ics/'
+        'IC Products Page': 'https://www.infineon.com/cms/de/product/power/motor-control-ics/brushed-dc-motor-driver-ics/multi-half-bridge-ics/'
     },
     ext_modules=[CMakeExtension("multi_half_bridge_py")],
     cmdclass={"build_ext": CMakeBuild},
     license='MIT',
     url='https://pypi.org/project/multi-half-bridge/',
     classifiers=[
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
     ],
     zip_safe=False,
 )

--- a/src/framework/raspberrypi/setup.py
+++ b/src/framework/raspberrypi/setup.py
@@ -53,13 +53,11 @@ class CMakeBuild(build_ext):
         build_args = []
 
         if self.compiler.compiler_type != "msvc":
-             # Using Ninja-build since it a) is available as a wheel and b)
-            # multithreads automatically. MSVC would require all variables be
-            # exported for Ninja to pick it up, which is a little tricky to do.
+             # Using Unix Makefiles instead of Ninja for better compatibility
             # Users can override the generator with CMAKE_GENERATOR in CMake
             # 3.15+.
             if not cmake_generator:
-                cmake_args += ["-GNinja"]
+                cmake_args += ["-GUnix Makefiles"]
         else:
              # Single config generators are handled "normally"
             single_config = any(x in cmake_generator for x in {"NMake", "Ninja"})


### PR DESCRIPTION
This pull request contains two essential changes and an additional update:

## 1. Reduction of SPI Frequency

The SPI frequency has been reduced from 15.6 MHz to 1.9 MHz.
Reason: The TLE94112, according to the datasheet (page 2, Infineon datasheet), supports a maximum of 5 MHz.
This adjustment ensures reliable communication with the TLE94112.


## 2. Fixing Python Module Installation Issues

Modifications have been made to the CMakeLists.txt file to fix missing paths that were previously not found.
The pybind11 library is now properly detected:
A function was added in setup.py to ensure the correct detection of pybind11.
Background: These changes make it possible to reinstall the Python module successfully.

## 3. Update of BCM2835 Library

The BCM2835 library has been updated to version 1.75.
